### PR TITLE
Header.php: Use a local font-awesome/css/font-awesome.min.css instead

### DIFF
--- a/Header.php
+++ b/Header.php
@@ -28,9 +28,7 @@ else
  
    
 <link href="css/bootstrap.min.css" rel="stylesheet" type="text/css"/>
-
-<!--<link href="font-awesome/css/font-awesome.min.css" rel="stylesheet" type="text/css"/> -->
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/fontawesome.min.css" />
+<link href="font-awesome/css/font-awesome.min.css" rel="stylesheet" type="text/css"/>
 <script src="http://118.25.96.118/nor/css/jquery.min.js" type="text/javascript"></script>
 <script src="http://118.25.96.118/nor/css/bootsrap.min.js" type="text/javascript"></script>
 <link href="http://118.25.96.118/nor/css/bootstrap.min.css" rel="stylesheet" type="text/css"/>


### PR DESCRIPTION
Use a local font-awesome/css/font-awesome.min.css instead of a remote one from https://cdnjs.cloudflare.com

I replaced the server side's Header.php with the [Header.php](https://github.com/lanlab-org/LRR/blob/master/Header.php) at lanlab-org.

After doing this, I found two icons on header could not display properly.
They look like two small rectangles.  The properly displayed icons should look like something in the following picture.

To fix this, I made a small change by using `font-awesome/css/font-awesome.min.css` instead of `https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/fontawesome.min.css`,  and it worked.



![Icons](https://user-images.githubusercontent.com/62275785/79298124-c46f7880-7f12-11ea-993f-4d8fa9f8c2bf.jpg)


**Hui**

