### PR TITLE
Adding web page icon and web page title to LRR

### DIFF
--- a/Header.php
+++ b/Header.php
@@ -25,7 +25,7 @@ else
 
 <html>
 <header>
- 
+<title>Lab Report Repository System</title>
    
 <link href="css/bootstrap.min.css" rel="stylesheet" type="text/css"/>
 <link href="font-awesome/css/font-awesome.min.css" rel="stylesheet" type="text/css"/>
@@ -33,6 +33,7 @@ else
 <script src="http://118.25.96.118/nor/css/bootsrap.min.js" type="text/javascript"></script>
 <link href="http://118.25.96.118/nor/css/bootstrap.min.css" rel="stylesheet" type="text/css"/>
 <script src="http://118.25.96.118/nor/css/jquery.datetimepicker.min.js" type="text/javascript"></script>
+<link rel = "shortcut icon" href = "logo_text.png">
 
 
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/48944710/83348407-ddb37380-a35e-11ea-8ef1-c5241cf21f9a.png)
Added a web page icon and web page title to LRR. The web page title shows the name of the page instead of the URL. For more details refer to the image that I have uploaded.

Team members:
Michelle - 201732120134
Martha - 201732120135
Robel - 201732120170