### PR TITLE
trim function 

### DIFF
--- a/Courses.php
+++ b/Courses.php
@@ -554,9 +554,8 @@ if( $_SESSION['user_type']=="Student")
     $student_id= $_SESSION['user_student_id'];
     if(!empty($_GET["search"]) || !empty($_GET["faculty"]))
     {
-        $search=trim($_GET["search"]); 
-         //trim is use to remove whitespace/leading space before or after a string//
-         //http://118.25.96.118/bugzilla/show_bug.cgi?id=59//
+       //use trim to remove whitespaces//
+        $search=trim($_GET["search"]);  
         $faculty=$_GET["faculty"];
     
        

--- a/Courses.php
+++ b/Courses.php
@@ -554,7 +554,9 @@ if( $_SESSION['user_type']=="Student")
     $student_id= $_SESSION['user_student_id'];
     if(!empty($_GET["search"]) || !empty($_GET["faculty"]))
     {
-        $search=$_GET["search"];
+        $search=trim($_GET["search"]); 
+         //trim is use to remove whitespace/leading space before or after a string//
+         //http://118.25.96.118/bugzilla/show_bug.cgi?id=59//
         $faculty=$_GET["faculty"];
     
        

--- a/Script.php
+++ b/Script.php
@@ -427,7 +427,7 @@ if (!empty($_POST["frm_uploadlab"])) {
          
          
     $deadline = $deadlinedate." ".$deadlinetime;
-    $date =  date("Y-m-d H:i");
+    $date =  date("Y-m-d H:i:s");
             
        
        
@@ -550,7 +550,7 @@ if (!empty($_POST["frm_submitlab"])) {
     $url = mysqli_real_escape_string($con, $_POST["url"]);
     
     $deadline = $deadlinedate." ".$deadlinetime;
-    $date = date("Y-m-d H:i");
+    $date = date("Y-m-d H:i:s");
     
     // GET UPLOADED FILES
     $labName = mysqli_query($con,"SELECT * FROM `lab_reports_table` WHERE Lab_Report_ID=$lab_id");
@@ -742,7 +742,7 @@ if (!empty($_GET["savemarks"])) {
         echo " Marks could not be greater than total";
         return;
     }
-    $date=  date("Y-m-d H:i");
+    $date=  date("Y-m-d H:i:s");
     $feedback="<br>@$date : ".$feedback;
         
     $sql="UPDATE `lab_report_submissions` SET `Marks`='$marks',`Status`='$status',"


### PR DESCRIPTION
It took me more than 3 nights to locate the place (in the source code) that causes this 'whitespace' problem.  After that, it took me just less than a minute to fix it.


Before bugfix

>   557 $search=$_GET["search"]; 

   
 
After bug fixed

>   557 $search=trim($_GET["search"]);

"trim()" is used to remove whitespace, there are three functions to use depending on the problem.  
ltrim() function-[used for removing whitespace before a string]

rtrim() function-[used for removing whitespace after a string]

trim()  function-[used for removing whitespace both before and after a string]
