### PR TITLE
Hui incorporate changes made by enock2

### DIFF
--- a/Script.php
+++ b/Script.php
@@ -131,7 +131,7 @@ if (!empty($_POST["frm_signup_2"])) {
     if ($con->query($sql) === TRUE) {
         header("Location: Courses.php");    
     } else {
-        echo "Something really bad (SQL insertion error) happend during sign up.";
+        echo "Something really bad (SQL insertion error) happened during sign up.";
     }
 }
 

--- a/Submissions.php
+++ b/Submissions.php
@@ -160,19 +160,19 @@ where Lab_Report_ID=$id and lab_report_submissions.Status='Pending' order by Sub
                 $att4=$row['Attachment4'];
                 $labid=$row['Lab_Report_ID'];
                                      
-                $submitted_std=$row['Student_id'];
+                $submitter_student_number=$row['Student_id'];
                 $submitted_group=$row['Course_Group_id'];
                 $Submission_ID=$row['Submission_ID'];
-                $names=$row['Full_Name'];
+                $student_name=$row['Full_Name'];
                 $groupname=$row['Group_Name'];
                 $groupleader=$row['Group_Leader'];  
                 $student_id=$row['sub_std'];
                                 
                 if($submitted_group==0)
                 {
-                    $submitted_by= $names."(".$student_id.")";
+                    $submitted_by= $student_name."(".$student_id.")";
                 } else {
-                    $submitted_by="$names $submitted_std <i>(GROUP)</i> $groupname ";
+                    $submitted_by="$student_name ($submitter_student_number) for group $groupname ";
                 }
 
                     $base_att1 = basename($att1);
@@ -196,7 +196,7 @@ where Lab_Report_ID=$id and lab_report_submissions.Status='Pending' order by Sub
                                        
                 echo "   <k href='#'>   <div class='btn btn-default break-word' style='dislay:block; word-wrap: break-word; border: 1px solid #F0F0F0;border-left: 4px solid #03407B;'>
   $title  <br> by: <b> $submitted_by </b>
-   <br> <span style='font-size:8pt'>Submitted at $posted   <button class='btn-sm btn-info' style='margin-left:50px;' onclick='mark($Submission_ID,\"$title\",$total)'>  Mark Submission</button><br> Attachments : $full_link </span>  
+   <br> <span style='font-size:8pt'>Submitted : $posted   <button class='btn-sm btn-info' style='margin-left:50px;' onclick='mark($Submission_ID,\"$title\",$total)'>  Mark Submission</button><br> Attachments : $full_link </span>  
 </div></k>";
                 
             }
@@ -256,17 +256,17 @@ where Lab_Report_ID=$id and lab_report_submissions.Status='Marked'  Order by lab
                 $att4=$row['Attachment4'];
                 $labid=$row['Lab_Report_ID'];
                                      
-                $submitted_std=$row['Student_id'];
+                $submitter_student_number=$row['Student_id'];
                 $submitted_group=$row['Course_Group_id'];
                 $Submission_ID=$row['Submission_ID'];
-                $names=$row['Full_Name'];
+                $student_name=$row['Full_Name'];
                 $student_id=$row['sub_std'];
                 $Visibility=$row['Visibility'];
                 $notes=$row['Notes'];
                                 
                 if($submitted_group==0)
                 {
-                    $submitted_by= $names."(".$student_id.")";
+                    $submitted_by= $student_name."(".$student_id.")";
                 } else {
                     $submitted_by="<i>(GROUP)</i> Group X " ;
                 }
@@ -352,16 +352,16 @@ where Lab_Report_ID=$id and lab_report_submissions.Status='Remarking'");
                                      
                 $remarking_reason=$row['Remarking_Reason'];
 
-                $submitted_std=$row['Student_id'];
+                $submitter_student_number=$row['Student_id'];
                 $submitted_group=$row['Course_Group_id'];
                 $Submission_ID=$row['Submission_ID'];
-                $names=$row['Full_Name'];
+                $student_name=$row['Full_Name'];
                 $student_id=$row['sub_std'];
                 $gname=$row['Group_Name '];
                                 
                 if($submitted_group==0)
                 {
-                    $submitted_by= $names."(".$student_id.")";
+                    $submitted_by= $student_name."(".$student_id.")";
                 } else {
                     $submitted_by="<i>(GROUP)</i> $gname" ;
                 }

--- a/Submissions.php
+++ b/Submissions.php
@@ -121,8 +121,9 @@ echo "<div class='alert' style='margin-left:20px;border-bottom:2px solid #1D91EF
             $result1 = mysqli_query($con,"SELECT `Submission_ID`, `Submission_Date`, lab_report_submissions.Lab_Report_ID,
     lab_report_submissions.Course_Group_id, `Attachment1`,
      `Notes`, `Attachment2`, `Attachment3`, `Attachment4`, `Marks`, lab_report_submissions.Status, 
-     `Title`,course_groups_table.Group_Name
+     `Title`,course_groups_table.Group_Name,course_groups_table.Group_Leader,users_table.Full_Name, users_table.Student_id
 FROM `lab_report_submissions`
+Left JOIN users_table  on users_table.Student_ID=lab_report_submissions.Student_id
 left JOIN course_groups_table on course_groups_table.Course_Group_id=lab_report_submissions.Course_Group_id
 where Lab_Report_ID=$id and lab_report_submissions.Status='Pending' order by Submission_Date desc");
         }
@@ -163,14 +164,15 @@ where Lab_Report_ID=$id and lab_report_submissions.Status='Pending' order by Sub
                 $submitted_group=$row['Course_Group_id'];
                 $Submission_ID=$row['Submission_ID'];
                 $names=$row['Full_Name'];
-                $groupname=$row['Group_Name']; 
+                $groupname=$row['Group_Name'];
+                $groupleader=$row['Group_Leader'];  
                 $student_id=$row['sub_std'];
                                 
                 if($submitted_group==0)
                 {
                     $submitted_by= $names."(".$student_id.")";
                 } else {
-                    $submitted_by="<i>(GROUP)</i> $groupname" ;
+                    $submitted_by="$names $submitted_std <i>(GROUP)</i> $groupname ";
                 }
 
                     $base_att1 = basename($att1);


### PR DESCRIPTION

![submitted-by-whom-after-fix-perfect](https://user-images.githubusercontent.com/62275785/116562974-39eb9280-a936-11eb-9cac-7df909727bf1.png)
![submitted-by-whom-after-fix-minor-problem](https://user-images.githubusercontent.com/62275785/116562982-3b1cbf80-a936-11eb-9ef6-79e9a5f448da.png)

This change shows who submitted the assignment on behalf of the group for Group Assignments.


This change works in one case, but not in another.  See the comment I made at 5:39pm on 29 April 2021 at the following link: http://118.25.96.118/kanboard/?controller=TaskViewController&action=readonly&task_id=855&token=485b98450b95a5802898252d2d51c62d4a8d613e87538d92419c9f6b534c


_@jeannickumba94  _at_  gmail.com

Thanks. I saw your update on Submissions.php.

It works for Software Project Management (CSC322) offered in the year 2019. See the picture submitted-by-whom-after-fix-perfect.png in the attachment.

However, it does not work so well for Intro to Object-oriented Analysis and Design (CSC312) offered in the year 2019. See the picture submitted-by-whom-after-fix-minor-problem.png in the attachment.

I noticed that you used two "LEFT JOIN". Probably you should be more careful while using complex JOIN operations.


-Hui